### PR TITLE
[Feat] MainAlbumView UI작업 + 화면전환 구현 완료

### DIFF
--- a/snaptime/Snaptime.xcodeproj/project.pbxproj
+++ b/snaptime/Snaptime.xcodeproj/project.pbxproj
@@ -36,8 +36,8 @@
 		298F7F7B2B6BA80F00A8DBC5 /* JoinPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298F7F7A2B6BA80F00A8DBC5 /* JoinPasswordViewController.swift */; };
 		298F7F7D2B6BA83C00A8DBC5 /* JoinNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298F7F7C2B6BA83C00A8DBC5 /* JoinNameViewController.swift */; };
 		298F7F7F2B6BA85700A8DBC5 /* JoinEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298F7F7E2B6BA85700A8DBC5 /* JoinEmailViewController.swift */; };
-		42AB7944914EE0F9CC2015E4 /* Pods_snaptime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B32E15A39E9F6588B693FD0 /* Pods_snaptime.framework */; };
 		A69A816C2B7E0F00006BAEB2 /* SnapCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A816B2B7E0F00006BAEB2 /* SnapCollectionViewCell.swift */; };
+		F04A5B9674D4282A9B96A66D /* Pods_Snaptime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C1CE3D481FC69735CD5FCEC /* Pods_Snaptime.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -73,7 +73,9 @@
 		298F7F7C2B6BA83C00A8DBC5 /* JoinNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinNameViewController.swift; sourceTree = "<group>"; };
 		298F7F7E2B6BA85700A8DBC5 /* JoinEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinEmailViewController.swift; sourceTree = "<group>"; };
 		344B46D68185013EBF95AF2F /* Pods-snaptime.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-snaptime.debug.xcconfig"; path = "Target Support Files/Pods-snaptime/Pods-snaptime.debug.xcconfig"; sourceTree = "<group>"; };
-		7B32E15A39E9F6588B693FD0 /* Pods_snaptime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_snaptime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5109E2DAD3B7C03D6DA70288 /* Pods-Snaptime.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Snaptime.debug.xcconfig"; path = "Target Support Files/Pods-Snaptime/Pods-Snaptime.debug.xcconfig"; sourceTree = "<group>"; };
+		57309D31F6C498072DAFD6FD /* Pods-Snaptime.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Snaptime.release.xcconfig"; path = "Target Support Files/Pods-Snaptime/Pods-Snaptime.release.xcconfig"; sourceTree = "<group>"; };
+		5C1CE3D481FC69735CD5FCEC /* Pods_Snaptime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Snaptime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A69A816B2B7E0F00006BAEB2 /* SnapCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapCollectionViewCell.swift; sourceTree = "<group>"; };
 		AB371C6CF6C883DC94E67745 /* Pods-snaptime.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-snaptime.release.xcconfig"; path = "Target Support Files/Pods-snaptime/Pods-snaptime.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -83,7 +85,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				42AB7944914EE0F9CC2015E4 /* Pods_snaptime.framework in Frameworks */,
+				F04A5B9674D4282A9B96A66D /* Pods_Snaptime.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,7 +95,7 @@
 		0B1A29E961772FF5DF3E3CE7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7B32E15A39E9F6588B693FD0 /* Pods_snaptime.framework */,
+				5C1CE3D481FC69735CD5FCEC /* Pods_Snaptime.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -271,6 +273,8 @@
 			children = (
 				344B46D68185013EBF95AF2F /* Pods-snaptime.debug.xcconfig */,
 				AB371C6CF6C883DC94E67745 /* Pods-snaptime.release.xcconfig */,
+				5109E2DAD3B7C03D6DA70288 /* Pods-Snaptime.debug.xcconfig */,
+				57309D31F6C498072DAFD6FD /* Pods-Snaptime.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -358,7 +362,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-snaptime-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-Snaptime-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -371,15 +375,15 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-snaptime/Pods-snaptime-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Snaptime/Pods-Snaptime-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-snaptime/Pods-snaptime-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Snaptime/Pods-Snaptime-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-snaptime/Pods-snaptime-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Snaptime/Pods-Snaptime-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -555,7 +559,7 @@
 		};
 		292977892B6618FB00FDC799 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 344B46D68185013EBF95AF2F /* Pods-snaptime.debug.xcconfig */;
+			baseConfigurationReference = 5109E2DAD3B7C03D6DA70288 /* Pods-Snaptime.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -583,7 +587,7 @@
 		};
 		2929778A2B6618FB00FDC799 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB371C6CF6C883DC94E67745 /* Pods-snaptime.release.xcconfig */;
+			baseConfigurationReference = 57309D31F6C498072DAFD6FD /* Pods-Snaptime.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/snaptime/Snaptime/Coordinator/AppCoordinator.swift
+++ b/snaptime/Snaptime/Coordinator/AppCoordinator.swift
@@ -41,7 +41,8 @@ final class AppCoordinator : Coordinator {
     var navigationController: UINavigationController
 
     func start() {
-        startAuthCoordinator()
+//        startAuthCoordinator()
+        startTabbarCoordinator() // 대현
     }
     
     init(navigationController: UINavigationController) {

--- a/snaptime/Snaptime/Coordinator/HomeCoordinator.swift
+++ b/snaptime/Snaptime/Coordinator/HomeCoordinator.swift
@@ -22,14 +22,16 @@ final class HomeCoordinator : Coordinator {
     }
 }
 
-extension HomeCoordinator : MainAlbumNavigation, DetailAlbumNavigation {
-    func presentMainAlbum() {
-        let mainAlbumVC = MainAlbumViewController(coordinator: self)
-        navigationController.pushViewController(mainAlbumVC, animated: true)
-    }
-    
-    func presentDetailAlbum() {
+extension HomeCoordinator : MainAlbumViewControllerDelegate, DetailAlbumNavigation {
+    func presentDetailView() {
+        print("presentDetailAlbum")
         let detailAlbumVC = DetailAlbumViewController(coordinator: self)
         navigationController.pushViewController(detailAlbumVC, animated: true)
+    }
+    
+    func presentMainAlbum() {
+        let mainAlbumVC = MainAlbumViewController()
+        mainAlbumVC.delegate = self
+        navigationController.pushViewController(mainAlbumVC, animated: true)
     }
 }

--- a/snaptime/Snaptime/Coordinator/HomeCoordinator.swift
+++ b/snaptime/Snaptime/Coordinator/HomeCoordinator.swift
@@ -24,7 +24,6 @@ final class HomeCoordinator : Coordinator {
 
 extension HomeCoordinator : MainAlbumViewControllerDelegate, DetailAlbumNavigation {
     func presentDetailView() {
-        print("presentDetailAlbum")
         let detailAlbumVC = DetailAlbumViewController(coordinator: self)
         navigationController.pushViewController(detailAlbumVC, animated: true)
     }

--- a/snaptime/Snaptime/Home/VCs/MainAlbumViewController.swift
+++ b/snaptime/Snaptime/Home/VCs/MainAlbumViewController.swift
@@ -8,25 +8,16 @@
 import UIKit
 import SnapKit
 
-protocol MainAlbumNavigation : AnyObject {
-    func presentMainAlbum()
-    func presentDetailAlbum()
+protocol MainAlbumViewControllerDelegate: AnyObject {
+    func presentDetailView()
 }
 
 final class MainAlbumViewController : BaseViewController {
-    weak var coordinator : MainAlbumNavigation?
+    weak var delegate : MainAlbumViewControllerDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    
-    init(coordinator: MainAlbumNavigation) {
-        self.coordinator = coordinator
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        print(delegate)
     }
     
     private let logoTextLabel : UILabel = {
@@ -44,7 +35,7 @@ final class MainAlbumViewController : BaseViewController {
         config.baseForegroundColor = .black
         button.configuration = config
         button.addAction(UIAction { _ in
-            self.coordinator?.presentDetailAlbum()
+            self.delegate?.presentDetailView()
         }, for: .touchUpInside)
         
         return button
@@ -124,6 +115,12 @@ extension MainAlbumViewController : UICollectionViewDataSource, UICollectionView
             for: indexPath
         ) as? SnapCollectionViewCell else { return UICollectionViewCell() }
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        print("didSelectItemAt")
+        print(delegate)
+        delegate?.presentDetailView()
     }
 }
 

--- a/snaptime/Snaptime/Home/VCs/MainAlbumViewController.swift
+++ b/snaptime/Snaptime/Home/VCs/MainAlbumViewController.swift
@@ -44,7 +44,7 @@ final class MainAlbumViewController : BaseViewController {
     private lazy var mainAlbumLabel : UILabel = {
         let label = UILabel()
         label.text = "모든 앨범"
-        label.font = .systemFont(ofSize: 16)
+        label.font = .systemFont(ofSize: 16, weight: .bold)
         return label
     }()
     
@@ -60,10 +60,21 @@ final class MainAlbumViewController : BaseViewController {
         return collectionView
     }()
     
-    
-    private func loadCollectionView() {
-        
-    }
+    private lazy var addSnapFloatingButton: UIButton = {
+        let button = UIButton()
+        var config = UIButton.Configuration.plain()
+        config.background.backgroundColor = .snaptimeBlue
+        config.baseForegroundColor = .white
+        config.cornerStyle = .capsule
+        config.image = UIImage(systemName: "plus")
+        button.configuration = config
+        button.layer.shadowRadius = 10
+        button.layer.shadowOpacity = 0.3
+        button.addAction(UIAction { [weak self] _ in
+            self?.delegate?.presentDetailView()
+        }, for: .touchUpInside)
+        return button
+    }()
     
     override func setupLayouts() {
         super.setupLayouts()
@@ -71,7 +82,8 @@ final class MainAlbumViewController : BaseViewController {
             logoTextLabel,
             addSnapButton,
             mainAlbumLabel,
-            mainAlbumCollectionView
+            mainAlbumCollectionView,
+            addSnapFloatingButton
         ].forEach {
             view.addSubview($0)
         }
@@ -100,6 +112,13 @@ final class MainAlbumViewController : BaseViewController {
             $0.top.equalTo(mainAlbumLabel.snp.bottom).offset(20)
             $0.left.right.equalTo(mainAlbumLabel)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-30)
+        }
+        
+        addSnapFloatingButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-30)
+            $0.right.equalTo(view.safeAreaLayoutGuide).offset(-30)
+            $0.width.equalTo(58)
+            $0.height.equalTo(58)
         }
     }
 }

--- a/snaptime/Snaptime/Home/VCs/MainAlbumViewController.swift
+++ b/snaptime/Snaptime/Home/VCs/MainAlbumViewController.swift
@@ -17,7 +17,6 @@ final class MainAlbumViewController : BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(delegate)
     }
     
     private let logoTextLabel : UILabel = {
@@ -54,7 +53,7 @@ final class MainAlbumViewController : BaseViewController {
         layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.register(SnapCollectionViewCell.self, forCellWithReuseIdentifier: "SnapCollectionViewCell")
+        collectionView.register(SnapCollectionViewCell.self, forCellWithReuseIdentifier: SnapCollectionViewCell.identifier)
         collectionView.dataSource = self
         collectionView.delegate = self
         return collectionView
@@ -130,15 +129,13 @@ extension MainAlbumViewController : UICollectionViewDataSource, UICollectionView
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: "SnapCollectionViewCell",
+            withReuseIdentifier: SnapCollectionViewCell.identifier,
             for: indexPath
         ) as? SnapCollectionViewCell else { return UICollectionViewCell() }
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print("didSelectItemAt")
-        print(delegate)
         delegate?.presentDetailView()
     }
 }

--- a/snaptime/Snaptime/Home/View/SnapCollectionViewCell.swift
+++ b/snaptime/Snaptime/Home/View/SnapCollectionViewCell.swift
@@ -18,7 +18,7 @@ final class SnapCollectionViewCell : UICollectionViewCell {
     private lazy var descriptionLabel : UILabel = {
         let label = UILabel()
         label.text = "2023"
-        label.font = .systemFont(ofSize: 12)
+        label.font = .systemFont(ofSize: 12, weight: .semibold)
         return label
     }()
     

--- a/snaptime/Snaptime/SceneDelegate.swift
+++ b/snaptime/Snaptime/SceneDelegate.swift
@@ -24,9 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let navigationController = UINavigationController()
             self.window?.rootViewController = navigationController
             
-//            let coordinator = AppCoordinator(navigationController: navigationController)
-            
-            let coordinator = HomeCoordinator(navigationController: navigationController) // 대현
+            let coordinator = AppCoordinator(navigationController: navigationController)
             coordinator.start()
             
             self.window?.makeKeyAndVisible()


### PR DESCRIPTION
## 이슈 번호 ⭐️

-

## summary 📋

MainAlbumView에서 DetailAlbumView로 화면 전환 구현 완료

MainAlbumView UI 피그마에 맞게 수정, 우측 하단 Floating Button 구현 완료

## 작업내용 👀

화면 전환과정에서 ViewController.init의 파라미터로 AlbumNavigation를 넘기는 방식이었는데, 해당 방법으로는 변수가 잘 전달이 안되어서, 델리게이트 패턴으로 바꾸었습니다!

이전 :

```
let detailAlbumVC = DetailAlbumViewController(coordinator: self)
navigationController.pushViewController(detailAlbumVC, animated: true)
```

변경 후 : 

```
let mainAlbumVC = MainAlbumViewController()
mainAlbumVC.delegate = self
navigationController.pushViewController(mainAlbumVC, animated: true)
```

## 기타 ➕

![image](https://github.com/AppCenter-Snaptime/snaptime-iOS/assets/58897339/95ecffa3-863d-4621-83c9-bbbc328fc587)
