### PR TITLE
[Feat] 댓글 화면 UI 수정 & 네트워크 로직 작성

### DIFF
--- a/snaptime/Snaptime.xcodeproj/project.pbxproj
+++ b/snaptime/Snaptime.xcodeproj/project.pbxproj
@@ -81,8 +81,9 @@
 		A68184F82BFB5DC800ECBDE3 /* AlbumSnapResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184F72BFB5DC800ECBDE3 /* AlbumSnapResDto.swift */; };
 		A68184FA2BFC496800ECBDE3 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184F92BFC496800ECBDE3 /* AccessToken.swift */; };
 		A68184FC2C0477C800ECBDE3 /* FindSnapResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184FB2C0477C800ECBDE3 /* FindSnapResDto.swift */; };
-		A68185002C32E27700ECBDE3 /* RoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184FF2C32E27700ECBDE3 /* RoundView.swift */; };
+		A68185002C32E27700ECBDE3 /* RoundImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184FF2C32E27700ECBDE3 /* RoundImageView.swift */; };
 		A68185022C32E7A500ECBDE3 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68185012C32E7A500ECBDE3 /* UITextField+.swift */; };
+		A68185042C34356C00ECBDE3 /* ParentReplyResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68185032C34356C00ECBDE3 /* ParentReplyResDto.swift */; };
 		A69A816C2B7E0F00006BAEB2 /* AlbumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A816B2B7E0F00006BAEB2 /* AlbumCollectionViewCell.swift */; };
 		A69A81BC2B876E2F006BAEB2 /* RecommendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A81BB2B876E2F006BAEB2 /* RecommendViewController.swift */; };
 		A69A81BF2B8777A8006BAEB2 /* RecommendSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A81BE2B8777A8006BAEB2 /* RecommendSectionView.swift */; };
@@ -170,8 +171,9 @@
 		A68184F72BFB5DC800ECBDE3 /* AlbumSnapResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumSnapResDto.swift; sourceTree = "<group>"; };
 		A68184F92BFC496800ECBDE3 /* AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessToken.swift; sourceTree = "<group>"; };
 		A68184FB2C0477C800ECBDE3 /* FindSnapResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindSnapResDto.swift; sourceTree = "<group>"; };
-		A68184FF2C32E27700ECBDE3 /* RoundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundView.swift; sourceTree = "<group>"; };
+		A68184FF2C32E27700ECBDE3 /* RoundImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundImageView.swift; sourceTree = "<group>"; };
 		A68185012C32E7A500ECBDE3 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		A68185032C34356C00ECBDE3 /* ParentReplyResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ParentReplyResDto.swift; path = ../../../../../../../Documents/ParentReplyResDto.swift; sourceTree = "<group>"; };
 		A69A816B2B7E0F00006BAEB2 /* AlbumCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCollectionViewCell.swift; sourceTree = "<group>"; };
 		A69A81BB2B876E2F006BAEB2 /* RecommendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendViewController.swift; sourceTree = "<group>"; };
 		A69A81BE2B8777A8006BAEB2 /* RecommendSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendSectionView.swift; sourceTree = "<group>"; };
@@ -421,6 +423,7 @@
 			isa = PBXGroup;
 			children = (
 				29FF6B8F2C1F15CD00CD5DCD /* SnapResDTO.swift */,
+				A68185032C34356C00ECBDE3 /* ParentReplyResDto.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -519,7 +522,7 @@
 				296167A92BBBC7A7003CA89C /* SnapPreviewViewController.swift */,
 				29B7D3CC2C020D1F00ADF15E /* SnapPreviewCollectionViewCell.swift */,
 				29E6EA122BFF8B13004F154F /* APIService.swift */,
-				A68184FF2C32E27700ECBDE3 /* RoundView.swift */,
+				A68184FF2C32E27700ECBDE3 /* RoundImageView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -694,7 +697,7 @@
 				296167AA2BBBC7A7003CA89C /* SnapPreviewViewController.swift in Sources */,
 				294FF9F22B6CA0DB00EDD005 /* TabBarCoordinator.swift in Sources */,
 				291FB1142BF63E7D0050AB90 /* UserAlbumModel.swift in Sources */,
-				A68185002C32E27700ECBDE3 /* RoundView.swift in Sources */,
+				A68185002C32E27700ECBDE3 /* RoundImageView.swift in Sources */,
 				A68184FC2C0477C800ECBDE3 /* FindSnapResDto.swift in Sources */,
 				294FF9FA2B6CA13C00EDD005 /* ProfileCoordinator.swift in Sources */,
 				29E6EA132BFF8B13004F154F /* APIService.swift in Sources */,
@@ -715,6 +718,7 @@
 				29F80BF72B858CB5003614AB /* ProfileStatusButton.swift in Sources */,
 				29F80BF92B85AECB003614AB /* ProfileListTabButton.swift in Sources */,
 				29B7D3CD2C020D1F00ADF15E /* SnapPreviewCollectionViewCell.swift in Sources */,
+				A68185042C34356C00ECBDE3 /* ParentReplyResDto.swift in Sources */,
 				296167AE2BBC1C41003CA89C /* SnapTagListViewController.swift in Sources */,
 				298F7F7F2B6BA85700A8DBC5 /* JoinEmailViewController.swift in Sources */,
 				29AA37B32BF23D81009EF296 /* UserProfileManager.swift in Sources */,

--- a/snaptime/Snaptime.xcodeproj/project.pbxproj
+++ b/snaptime/Snaptime.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		A68184F82BFB5DC800ECBDE3 /* AlbumSnapResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184F72BFB5DC800ECBDE3 /* AlbumSnapResDto.swift */; };
 		A68184FA2BFC496800ECBDE3 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184F92BFC496800ECBDE3 /* AccessToken.swift */; };
 		A68184FC2C0477C800ECBDE3 /* FindSnapResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184FB2C0477C800ECBDE3 /* FindSnapResDto.swift */; };
+		A68185002C32E27700ECBDE3 /* RoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68184FF2C32E27700ECBDE3 /* RoundView.swift */; };
+		A68185022C32E7A500ECBDE3 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68185012C32E7A500ECBDE3 /* UITextField+.swift */; };
 		A69A816C2B7E0F00006BAEB2 /* AlbumCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A816B2B7E0F00006BAEB2 /* AlbumCollectionViewCell.swift */; };
 		A69A81BC2B876E2F006BAEB2 /* RecommendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A81BB2B876E2F006BAEB2 /* RecommendViewController.swift */; };
 		A69A81BF2B8777A8006BAEB2 /* RecommendSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69A81BE2B8777A8006BAEB2 /* RecommendSectionView.swift */; };
@@ -168,6 +170,8 @@
 		A68184F72BFB5DC800ECBDE3 /* AlbumSnapResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumSnapResDto.swift; sourceTree = "<group>"; };
 		A68184F92BFC496800ECBDE3 /* AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessToken.swift; sourceTree = "<group>"; };
 		A68184FB2C0477C800ECBDE3 /* FindSnapResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindSnapResDto.swift; sourceTree = "<group>"; };
+		A68184FF2C32E27700ECBDE3 /* RoundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundView.swift; sourceTree = "<group>"; };
+		A68185012C32E7A500ECBDE3 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		A69A816B2B7E0F00006BAEB2 /* AlbumCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumCollectionViewCell.swift; sourceTree = "<group>"; };
 		A69A81BB2B876E2F006BAEB2 /* RecommendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendViewController.swift; sourceTree = "<group>"; };
 		A69A81BE2B8777A8006BAEB2 /* RecommendSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendSectionView.swift; sourceTree = "<group>"; };
@@ -197,6 +201,7 @@
 				A69A81C32B877F2D006BAEB2 /* UITableViewCell+.swift */,
 				A652BD792B9AA5C500CA9F37 /* CGPoint+.swift */,
 				295DF0512BC505A100112DE7 /* UILabel+.swift */,
+				A68185012C32E7A500ECBDE3 /* UITextField+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -514,6 +519,7 @@
 				296167A92BBBC7A7003CA89C /* SnapPreviewViewController.swift */,
 				29B7D3CC2C020D1F00ADF15E /* SnapPreviewCollectionViewCell.swift */,
 				29E6EA122BFF8B13004F154F /* APIService.swift */,
+				A68184FF2C32E27700ECBDE3 /* RoundView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -668,6 +674,7 @@
 				298F7F612B6BA38000A8DBC5 /* CommunityViewController.swift in Sources */,
 				296E0F672B8859E700758653 /* AlbumAndTagListView.swift in Sources */,
 				29FF6B902C1F15CD00CD5DCD /* SnapResDTO.swift in Sources */,
+				A68185022C32E7A500ECBDE3 /* UITextField+.swift in Sources */,
 				298F7F7D2B6BA83C00A8DBC5 /* JoinNameViewController.swift in Sources */,
 				29F80BF52B8589AC003614AB /* ProfileStatusView.swift in Sources */,
 				292977782B6618FA00FDC799 /* AppDelegate.swift in Sources */,
@@ -687,6 +694,7 @@
 				296167AA2BBBC7A7003CA89C /* SnapPreviewViewController.swift in Sources */,
 				294FF9F22B6CA0DB00EDD005 /* TabBarCoordinator.swift in Sources */,
 				291FB1142BF63E7D0050AB90 /* UserAlbumModel.swift in Sources */,
+				A68185002C32E27700ECBDE3 /* RoundView.swift in Sources */,
 				A68184FC2C0477C800ECBDE3 /* FindSnapResDto.swift in Sources */,
 				294FF9FA2B6CA13C00EDD005 /* ProfileCoordinator.swift in Sources */,
 				29E6EA132BFF8B13004F154F /* APIService.swift in Sources */,

--- a/snaptime/Snaptime/Comment/VCs/CommentViewController.swift
+++ b/snaptime/Snaptime/Comment/VCs/CommentViewController.swift
@@ -26,7 +26,19 @@ final class CommentViewController: BaseViewController {
         return view
     }()
     
-    private lazy var commentColelctionView: UICollectionView = {
+    private lazy var separatorView2: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(hexCode: "dddddd")
+        return view
+    }()
+    
+    private lazy var separatorView3: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(hexCode: "dddddd")
+        return view
+    }()
+    
+    private lazy var commentCollectionView: UICollectionView = {
         let config = UICollectionViewCompositionalLayoutConfiguration()
         let layout = UICollectionViewCompositionalLayout(
             sectionProvider: {(
@@ -82,6 +94,37 @@ final class CommentViewController: BaseViewController {
         return collectionView
     }()
     
+    private lazy var replyImageView: UIImageView = {
+        let imageView = RoundImageView()
+        imageView.image = UIImage(systemName: "person")
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private lazy var replyTextField: UITextField = {
+        let textField = UITextField()
+        textField.backgroundColor = .systemGray5
+        textField.placeholder = "Jocelyn에게 댓글달기"
+        textField.font = .systemFont(ofSize: 12)
+        textField.addLeftPadding(16)
+        return textField
+    }()
+    
+    private lazy var replySubmitButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "arrow.right.circle.fill"), for: .normal)
+        button.tintColor = .snaptimeBlue
+        return button
+    }()
+    
+    private lazy var replyStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.spacing = 16
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        return stackView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupDataSource()
@@ -99,7 +142,7 @@ final class CommentViewController: BaseViewController {
         }
         
         dataSource = UICollectionViewDiffableDataSource<Int, Int>(
-            collectionView: commentColelctionView, 
+            collectionView: commentCollectionView, 
             cellProvider: ({(
                 collectionView: UICollectionView,
                 indexPath: IndexPath,
@@ -122,9 +165,9 @@ final class CommentViewController: BaseViewController {
         
         dataSource.supplementaryViewProvider = {(view, kind, index) in
             if kind == "header" {
-                return self.commentColelctionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: index)
+                return self.commentCollectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration, for: index)
             } else {
-                return self.commentColelctionView.dequeueConfiguredReusableSupplementary(using: footerRegistration, for: index)
+                return self.commentCollectionView.dequeueConfiguredReusableSupplementary(using: footerRegistration, for: index)
             }
         }
         
@@ -149,14 +192,28 @@ final class CommentViewController: BaseViewController {
     // MARK: -- Setup UI
     override func setupLayouts() {
         self.view.backgroundColor = .systemBackground
-        
+        [
+            replyImageView,
+            replyTextField,
+            replySubmitButton
+        ].forEach {
+            replyStackView.addArrangedSubview($0)
+        }
         [
             titleLabel,
             separatorView,
-            commentColelctionView
+            separatorView2,
+            separatorView3,
+            commentCollectionView,
+            replyStackView
         ].forEach {
             self.view.addSubview($0)
         }
+        
+        // setup UI
+        
+        replyTextField.layer.cornerRadius = 15
+        replyTextField.clipsToBounds = true
     }
     
     override func setupConstraints() {
@@ -171,10 +228,41 @@ final class CommentViewController: BaseViewController {
             $0.height.equalTo(1)
         }
         
-        commentColelctionView.snp.makeConstraints {
+        replyImageView.snp.makeConstraints {
+            $0.width.height.equalTo(32)
+        }
+        
+        replyTextField.snp.makeConstraints {
+            $0.height.equalTo(30)
+        }
+        
+        replySubmitButton.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+        }
+        
+        replyStackView.snp.makeConstraints {
+            $0.left.equalTo(view.safeAreaLayoutGuide).offset(20)
+            $0.right.equalTo(view.safeAreaLayoutGuide).offset(-20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(60)
+        }
+        
+        separatorView2.snp.makeConstraints {
+            $0.top.equalTo(replyStackView.snp.top)
+            $0.left.right.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(1)
+        }
+        
+        separatorView3.snp.makeConstraints {
+            $0.top.equalTo(replyStackView.snp.bottom)
+            $0.left.right.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(1)
+        }
+        
+        commentCollectionView.snp.makeConstraints {
             $0.top.equalTo(separatorView.snp.bottom)
             $0.left.right.equalTo(view.safeAreaLayoutGuide)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(replyStackView.snp.top)
         }
     }
 }

--- a/snaptime/Snaptime/Comment/VCs/CommentViewController.swift
+++ b/snaptime/Snaptime/Comment/VCs/CommentViewController.swift
@@ -5,13 +5,26 @@
 //  Created by 이대현 on 4/2/24.
 //
 
+import Alamofire
 import UIKit
 
+
 protocol CommentViewControllerDelegate: AnyObject {
-    func presentCommentVC()
+    func presentCommentVC(id: Int)
 }
 
 final class CommentViewController: BaseViewController {
+    init(snapID: Int) {
+        self.snapID = snapID
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private let snapID: Int
+    private var parentComments: [FindReplyResDto] = []
     weak var delegate: CommentViewControllerDelegate?
     
     private lazy var titleLabel: UILabel = {
@@ -45,6 +58,11 @@ final class CommentViewController: BaseViewController {
             sectionIndex: Int,
             layoutEnvironment: NSCollectionLayoutEnvironment
             ) -> NSCollectionLayoutSection? in
+                /*
+                 원 댓글 : Header
+                 답글 : item
+                 답글 추가/가리기 : Footer
+                 */
                 // 대댓글 item
                 let item = NSCollectionLayoutItem(
                     layoutSize: NSCollectionLayoutSize(
@@ -128,8 +146,54 @@ final class CommentViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupDataSource()
+        self.fetchComment()
     }
     
+    
+    // MARK: -- 댓글 목록 서버 통신
+    private func fetchComment() {
+        // TODO: 우선 pageNum 1로 고정했는데, 2,3페이지가 있는지 어떻게 알까
+        
+        let url = "http://na2ru2.me:6308/parent-replies/1"
+        let headers: HTTPHeaders = [
+            "Authorization": ACCESS_TOKEN,
+            "accept": "*/*"
+        ]
+        let parameters: Parameters = [
+            "snapId" : self.snapID,
+            "pageNum" : 1
+        ]
+        AF.request(
+            url,
+            method: .get,
+            parameters: parameters,
+            encoding: URLEncoding.default,
+            headers: headers
+        )
+        .validate(statusCode: 200..<300)
+        .responseJSON { response in
+            switch response.result {
+            case .success(let data):
+                print("success")
+                print(data)
+                guard let data = response.data else { return }
+                
+                do {
+                    let decoder = JSONDecoder()
+                    let result = try decoder.decode(ParentReplyResDto.self, from: data)
+                    print(result)
+                    self.parentComments = result.result
+                    DispatchQueue.main.async {
+                        self.applySnapShot(data: result.result)
+                    }
+                } catch {
+                    print(error)
+                }
+            case .failure(let error):
+                print(String(describing: error.errorDescription))
+            }
+        }
+    }
     // MARK: -- Setup CollectionView
     
     // collectionView dataSource
@@ -138,7 +202,7 @@ final class CommentViewController: BaseViewController {
     private func setupDataSource() {
         let cellRegistration = UICollectionView.CellRegistration<CommentCollectionViewCell, Int> {
             (cell, indexPath, identifier) in
-            // cell.nickName.text = "haha"
+            cell.setupUI(comment: identifier)
         }
         
         dataSource = UICollectionViewDiffableDataSource<Int, Int>(
@@ -157,6 +221,7 @@ final class CommentViewController: BaseViewController {
         
         let headerRegistration = UICollectionView.SupplementaryRegistration<CommentSupplementaryHeaderView>(elementKind: "header") { supplementaryView, elementKind, indexPath in
             // header 세팅
+            supplementaryView.setupUI(comment: self.parentComments[indexPath.section])
         }
         
         let footerRegistration = UICollectionView.SupplementaryRegistration<CommentSupplementaryFooterView>(elementKind: "footer") { supplementaryView, elementKind, indexPath in
@@ -170,13 +235,15 @@ final class CommentViewController: BaseViewController {
                 return self.commentCollectionView.dequeueConfiguredReusableSupplementary(using: footerRegistration, for: index)
             }
         }
-        
+    }
+    
+    private func applySnapShot(data: [FindReplyResDto]) {
         var snapshot = NSDiffableDataSourceSnapshot<Int, Int>()
         
         var identifierOffset = 0 // 아이템의 identifier
-        let itemPerSection = 3
+        let itemPerSection = 3 // 답글의 개수, 테스트 데이터로 추가 가능
         
-        for idx in 0...10 {
+        for idx in 0..<data.count {
             snapshot.appendSections([idx])
             
             let maxIdentifier = identifierOffset + itemPerSection

--- a/snaptime/Snaptime/Comment/View/CommentCollectionViewCell.swift
+++ b/snaptime/Snaptime/Comment/View/CommentCollectionViewCell.swift
@@ -20,6 +20,11 @@ final class CommentCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setupUI(comment: Int) {
+        let comment = FindReplyResDto(writerLoginId: "", writerProfilePhotoURL: "", writerUserName: String(comment), content: "", replyId: 0)
+        self.commentView.setupUI(comment: comment)
+    }
+    
     private func setLayout() {
         self.contentView.addSubview(commentView)
     }

--- a/snaptime/Snaptime/Comment/View/CommentSupplementaryHeaderView.swift
+++ b/snaptime/Snaptime/Comment/View/CommentSupplementaryHeaderView.swift
@@ -21,6 +21,10 @@ final class CommentSupplementaryHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setupUI(comment: FindReplyResDto) {
+        contentView.setupUI(comment: comment)
+    }
+    
     private func setLayout() {
         self.addSubview(contentView)
     }

--- a/snaptime/Snaptime/Comment/View/SingleCommentView.swift
+++ b/snaptime/Snaptime/Comment/View/SingleCommentView.swift
@@ -5,11 +5,12 @@
 //  Created by 이대현 on 4/2/24.
 //
 
+import Kingfisher
 import UIKit
 
 class SingleCommentView: UIView {
-    private lazy var profileImageView: UIImageView = {
-        let imageView = UIImageView()
+    private lazy var profileImageView: RoundImageView = {
+        let imageView = RoundImageView()
         imageView.image = UIImage(systemName: "person")
         return imageView
     }()
@@ -62,6 +63,31 @@ class SingleCommentView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setupUI(comment: FindReplyResDto) {
+        self.nameLabel.text = comment.writerUserName
+        self.commentLabel.text = comment.content
+        if let url = URL(string: comment.writerProfilePhotoURL) {
+            
+            let modifier = AnyModifier { request in
+                var r = request
+                r.setValue("*/*", forHTTPHeaderField: "accept")
+                r.setValue(ACCESS_TOKEN, forHTTPHeaderField: "Authorization")
+                return r
+            }
+            
+            self.profileImageView.kf.setImage(with: url, options: [.requestModifier(modifier)]) { result in
+                switch result {
+                case .success(_):
+                    print("success fetch image")
+                case .failure(let error):
+                    print("error")
+                    print(error)
+                }
+            }
+            
+        }
+    }
+    
     private func setLayout() {
         
         [
@@ -74,7 +100,7 @@ class SingleCommentView: UIView {
         }
         
         [
-            nameLabel, 
+            nameLabel,
             beforeDateLabel
         ].forEach {
             self.upperStackView.addArrangedSubview($0)
@@ -92,7 +118,7 @@ class SingleCommentView: UIView {
             $0.left.equalTo(profileImageView.snp.right).offset(15)
             $0.top.equalTo(profileImageView).offset(-3)
         }
-
+        
         commentLabel.snp.makeConstraints {
             $0.left.equalTo(upperStackView)
             $0.top.equalTo(upperStackView.snp.bottom).offset(2)

--- a/snaptime/Snaptime/Community/VCs/CommunityViewController.swift
+++ b/snaptime/Snaptime/Community/VCs/CommunityViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 protocol CommunityViewControllerDelegate: AnyObject {
     func presentCommunity()
     func presentNotification()
-    func presentCommentVC()
+    func presentCommentVC(id: Int)
 }
 
 final class CommunityViewController: BaseViewController {
@@ -121,6 +121,7 @@ extension CommunityViewController: UICollectionViewDelegateFlowLayout {
 
 extension CommunityViewController: SnapCollectionViewCellDelegate {
     func didTapCommentButton() {
-        delegate?.presentCommentVC()
+        // TODO: snap id 추가하기
+        delegate?.presentCommentVC(id: 1)
     }
 }

--- a/snaptime/Snaptime/Components/APIService.swift
+++ b/snaptime/Snaptime/Components/APIService.swift
@@ -21,6 +21,7 @@ enum APIService {
     case fetchUserAlbum(loginId: String)
     case fetchCommunitySnap(pageNum: Int)
     case fetchSnap(albumId: Int)
+    case fetchComment(snapId: Int, pageNum: Int)
 }
 
 extension APIService {
@@ -40,6 +41,9 @@ extension APIService {
             
         case .fetchSnap(let albumId):
             "/album/\(albumId)?album_id=\(albumId)"
+            
+        case .fetchComment(_, let pageNum):
+            "/parent_replies/\(pageNum)"
         }
     }
     
@@ -49,7 +53,8 @@ extension APIService {
             .fetchUserProfileCount,
             .fetchUserAlbum,
             .fetchCommunitySnap,
-            .fetchSnap:
+            .fetchSnap,
+            .fetchComment:
                 .get
         }
     }
@@ -105,6 +110,11 @@ extension APIService {
                             else if case .fetchSnap = self {
                                 let snap = try JSONDecoder().decode(CommonResponseDtoFindAlbumResDto.self, from: data)
                                 
+                            }
+                            
+                            else if case .fetchComment = self {
+                                let comment = try JSONDecoder().decode(ParentReplyResDto.self, from: data)
+                                completion(.success(comment))
                             }
                         } catch {
                             completion(.failure(FetchError.jsonDecodeError))

--- a/snaptime/Snaptime/Components/RoundImageView.swift
+++ b/snaptime/Snaptime/Components/RoundImageView.swift
@@ -1,5 +1,5 @@
 //
-//  RoundView.swift
+//  RoundImageView.swift
 //  Snaptime
 //
 //  Created by 이대현 on 7/1/24.

--- a/snaptime/Snaptime/Components/RoundView.swift
+++ b/snaptime/Snaptime/Components/RoundView.swift
@@ -1,0 +1,15 @@
+//
+//  RoundView.swift
+//  Snaptime
+//
+//  Created by 이대현 on 7/1/24.
+//
+
+import UIKit
+
+final class RoundImageView: UIImageView {
+    override func layoutSubviews() {
+        self.layer.cornerRadius = self.frame.width / 2
+        self.clipsToBounds = true
+    }
+}

--- a/snaptime/Snaptime/Components/SnapCollectionViewCell.swift
+++ b/snaptime/Snaptime/Components/SnapCollectionViewCell.swift
@@ -141,7 +141,7 @@ final class SnapCollectionViewCell: UICollectionViewCell {
 //        if let tagList = data {
 //            tagLabel.text = "with @\(tagList)"
 //        }
-        self.loadImage(data: data.photoURL, imageView: photoImageView)
+        self.loadImage(data: data.snapPhotoURL, imageView: photoImageView)
         postLabel.text = data.oneLineJournal
 //        postDateLabel.text = data.snapCreatedDate
         postDateLabel.text = "2024.01.09"

--- a/snaptime/Snaptime/Components/SnapViewController.swift
+++ b/snaptime/Snaptime/Components/SnapViewController.swift
@@ -10,14 +10,23 @@ import SnapKit
 import Alamofire
 
 protocol SnapViewControllerDelegate: AnyObject {
-    func presentCommentVC()
+    func presentCommentVC(id: Int)
 }
 
 final class SnapViewController: BaseViewController {
     weak var delegate: SnapViewControllerDelegate?
     private let snapId: Int
     
-    private var snap: FindSnapResDto = FindSnapResDto(id: 0, oneLineJournal: "", photoURL: "", albumName: "", userUid: "")
+    private var snap: FindSnapResDto = FindSnapResDto(
+        snapId: 0,
+        oneLineJournal: "",
+        snapPhotoURL: "",
+        snapCreatedDate: "",
+        snapModifiedDate: "",
+        loginId: "",
+        profilePhotoURL: "",
+        userName: ""
+    )
     
     init(snapId: Int) {
         self.snapId = snapId
@@ -139,6 +148,6 @@ extension SnapViewController: UICollectionViewDelegateFlowLayout {
 
 extension SnapViewController: SnapCollectionViewCellDelegate {
     func didTapCommentButton() {
-        delegate?.presentCommentVC()
+        delegate?.presentCommentVC(id: self.snapId)
     }
 }

--- a/snaptime/Snaptime/Coordinator/CommunityCoordinator.swift
+++ b/snaptime/Snaptime/Coordinator/CommunityCoordinator.swift
@@ -23,9 +23,10 @@ final class CommunityCoordinator: Coordinator {
     }
 }
 
-extension CommunityCoordinator: CommunityViewControllerDelegate,
-                                NotificationViewControllerDelegate,
-                                    CommentViewControllerDelegate {
+extension CommunityCoordinator:
+    CommunityViewControllerDelegate,
+    NotificationViewControllerDelegate,
+    CommentViewControllerDelegate {
     func presentCommunity() {
         let communityVC = CommunityViewController()
         communityVC.delegate = self
@@ -38,8 +39,8 @@ extension CommunityCoordinator: CommunityViewControllerDelegate,
         navigationController.pushViewController(notificationVC, animated: true)
     }
     
-    func presentCommentVC() {
-        let commentVC = CommentViewController()
+    func presentCommentVC(id: Int) {
+        let commentVC = CommentViewController(snapID: id)
         commentVC.delegate = self
         commentVC.modalPresentationStyle = UIModalPresentationStyle.automatic
         navigationController.present(commentVC, animated: true, completion: nil)

--- a/snaptime/Snaptime/Coordinator/HomeCoordinator.swift
+++ b/snaptime/Snaptime/Coordinator/HomeCoordinator.swift
@@ -81,8 +81,8 @@ extension HomeCoordinator: MainAlbumViewControllerDelegate,
         navigationController.pushViewController(snapTagListVC, animated: true)
     }
     
-    func presentCommentVC() {
-        let commentVC = CommentViewController()
+    func presentCommentVC(id: Int) {
+        let commentVC = CommentViewController(snapID: id)
         commentVC.delegate = self
         commentVC.modalPresentationStyle = UIModalPresentationStyle.automatic
         navigationController.present(commentVC, animated: true, completion: nil)

--- a/snaptime/Snaptime/Coordinator/ProfileCoordinator.swift
+++ b/snaptime/Snaptime/Coordinator/ProfileCoordinator.swift
@@ -31,8 +31,8 @@ extension ProfileCoordinator: MyProfileViewControllerDelegate,
                               NotificationViewControllerDelegate,
                               CommentViewControllerDelegate {
     
-    func presentCommentVC() {
-        let commentVC = CommentViewController()
+    func presentCommentVC(id: Int) {
+        let commentVC = CommentViewController(snapID: id)
         commentVC.delegate = self
         commentVC.modalPresentationStyle = UIModalPresentationStyle.automatic
         navigationController.present(commentVC, animated: true, completion: nil)

--- a/snaptime/Snaptime/Extension/UITextField+.swift
+++ b/snaptime/Snaptime/Extension/UITextField+.swift
@@ -1,0 +1,16 @@
+//
+//  UITextField+.swift
+//  Snaptime
+//
+//  Created by 이대현 on 7/1/24.
+//
+
+import UIKit
+
+extension UITextField {
+    func addLeftPadding(_ padding : Int) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: padding, height: Int(self.frame.height)))
+        self.leftView = paddingView
+        self.leftViewMode = .always
+    }
+}

--- a/snaptime/Snaptime/Home/Model/Album.swift
+++ b/snaptime/Snaptime/Home/Model/Album.swift
@@ -21,9 +21,9 @@ struct Album {
     }
     
     init(_ dto: FindSnapResDto) {
-        self.id = dto.id
+        self.id = dto.snapId
         self.name = dto.oneLineJournal
-        self.photoURL = dto.photoURL
+        self.photoURL = dto.snapPhotoURL
     }
     
     let id: Int

--- a/snaptime/Snaptime/Home/Model/FindSnapResDto.swift
+++ b/snaptime/Snaptime/Home/Model/FindSnapResDto.swift
@@ -19,9 +19,12 @@ struct FindAlbumResDto: Codable {
 }
 
 struct FindSnapResDto: Codable {
-    let id: Int
+    let snapId: Int
     let oneLineJournal: String
-    let photoURL: String
-    let albumName: String
-    let userUid: String
+    let snapPhotoURL: String
+    let snapCreatedDate: String
+    let snapModifiedDate: String
+    let loginId: String
+    let profilePhotoURL: String
+    let userName: String
 }


### PR DESCRIPTION
## 이슈 번호 ⭐️


## summary 📋

1. 아래쪽 이미지, textfield, 댓글 업로드 ui 추가
2. 네트워크 로직 작성 - 원댓글의 프로필 이미지, 작성자, 댓글 내용 서버로부터 fetch

---
- 이후 작업해야 할 것들
  - 댓글에서 시간 표시하는 부분 구현하기 (UI에서 '30분 전' 표시 부분)
  - 댓글의 답글 부분 네트워크 로직 작성
  - 답글 펼치기/가리기 기능 구현
  
## 작업내용 👀

Alamofire 사용할 때 원래 보원이가 만든 APIService 사용하려고 했는데,
parameter를 보낼 수 없는 구조여서 APIService에 통합하는 건 실패했다 ㅜㅜ

<img width="648" alt="image" src="https://github.com/AppCenter-Snaptime/snaptime-iOS/assets/58897339/308f6a81-47ce-43a0-8c1b-df324685f581">


## 기타 ➕

![image](https://github.com/AppCenter-Snaptime/snaptime-iOS/assets/58897339/2968bb59-b8e4-4682-8a27-64bb4a64f982)
